### PR TITLE
Fix standalone expressions being rewritten as commands

### DIFF
--- a/make_profiler/parser.py
+++ b/make_profiler/parser.py
@@ -66,15 +66,15 @@ def parse(fd):
             })
         )
 
+    def next_belongs_to_target():
+        token, _ = it.peek()
+        return token == Tokens.command
+
     def parse_body():
         body = []
         try:
-            while it.peek()[0] != Tokens.target:
-                token = next(it)
-                if token[0] == Tokens.command:
-                    body.append((token[0], token[1]))
-                else:
-                    body.append(token)
+            while next_belongs_to_target():
+                body.append(next(it))
         except StopIteration:
             pass
         return body


### PR DESCRIPTION
Fixes #5 . The problem was that in case of

```
all: app.exe test.exe
export PATH=/abc:/def
```

standalone expressions like `export PATH`, while parsed correctly, were rewritten to `/tmp/tmpMakefile` as previous target commands surrounded by `"start/finish"` timestamps:

```
all: app.exe test.exe
	printf "start"
export PATH=/abc:/def
	printf "finish"      # <<< Make cannot parse this line
```